### PR TITLE
HTML saved as UTF8 to prevent errors on encoding

### DIFF
--- a/twill/commands.py
+++ b/twill/commands.py
@@ -250,7 +250,7 @@ def save_html(filename=None):
             filename = 'index.html'
         log.info("Using filename '%s'", filename)
 
-    f = open(filename, 'w')
+    f = open(filename, 'w', encoding="utf-8")
     f.write(html)
     f.close()
 


### PR DESCRIPTION
Fixes errors on HTML encoding when some special characters are encountered.